### PR TITLE
refactor: response dto, request dto를 controller layer로 이동

### DIFF
--- a/src/main/kotlin/com/template/common/dto/BasicMessageResponseDto.kt
+++ b/src/main/kotlin/com/template/common/dto/BasicMessageResponseDto.kt
@@ -1,3 +1,0 @@
-package com.template.common.dto
-
-data class BasicMessageResponseDto(val message: String)

--- a/src/main/kotlin/com/template/common/response/BasicMessageResponse.kt
+++ b/src/main/kotlin/com/template/common/response/BasicMessageResponse.kt
@@ -1,0 +1,3 @@
+package com.template.common.response
+
+data class BasicMessageResponse(val message: String)

--- a/src/main/kotlin/com/template/user/controller/UserApiController.kt
+++ b/src/main/kotlin/com/template/user/controller/UserApiController.kt
@@ -1,11 +1,18 @@
 package com.template.user.controller
 
 import com.template.config.annotation.LoggedInUser
+import com.template.user.controller.request.AccessTokenUpdateRequest
+import com.template.user.controller.request.UserCreateRequest
+import com.template.user.controller.request.UserLoginRequest
+import com.template.user.controller.response.AccessTokenUpdateResponse
+import com.template.user.controller.response.UserInfoResponse
+import com.template.user.controller.response.UserLoginResponse
 import com.template.user.domain.User
-import com.template.user.dto.*
 import com.template.user.service.UserService
+import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 import reactor.core.publisher.Mono
+import java.net.URI
 import javax.validation.Valid
 
 @RestController
@@ -15,14 +22,26 @@ class UserApiController(
 ) {
 
     @PostMapping("/signup")
-    fun createUser(@RequestBody @Valid requestDto: Mono<UserCreateRequestDto>) = userService.create(requestDto)
+    fun createUser(@RequestBody @Valid request: Mono<UserCreateRequest>): Mono<ResponseEntity<UserInfoResponse>> {
+        return userService.create(request.map { it.toDto() })
+            .map { ResponseEntity.created(URI.create("/v1/user")).body(UserInfoResponse.from(it.body!!)) }
+    }
 
     @PostMapping("/login")
-    fun login(@RequestBody @Valid requestDto: Mono<UserLoginRequestDto>) = userService.login(requestDto)
+    fun login(@RequestBody @Valid request: Mono<UserLoginRequest>): Mono<ResponseEntity<UserLoginResponse>> {
+        return userService.login(request.map { it.toDto() })
+            .map { ResponseEntity.ok().body(UserLoginResponse.from(it.body!!)) }
+    }
 
     @GetMapping("/info")
-    fun getUserInfo(@LoggedInUser user: User) = userService.getInfo(Mono.just(user))
+    fun getUserInfo(@LoggedInUser user: User): Mono<ResponseEntity<UserInfoResponse>> {
+        return userService.getInfo(Mono.just(user))
+            .map { ResponseEntity.ok().body(UserInfoResponse.from(it.body!!)) }
+    }
 
     @PostMapping("/update-token")
-    fun updateAccessToken(@RequestBody @Valid dto: Mono<AccessTokenUpdateRequestDto>) = userService.updateAccessToken(dto)
+    fun updateAccessToken(@RequestBody @Valid request: Mono<AccessTokenUpdateRequest>): Mono<ResponseEntity<AccessTokenUpdateResponse>> {
+        return userService.updateAccessToken(request.map { it.refreshToken })
+            .map { ResponseEntity.ok().body(AccessTokenUpdateResponse.from(it.body!!)) }
+    }
 }

--- a/src/main/kotlin/com/template/user/controller/request/AccessTokenUpdateRequest.kt
+++ b/src/main/kotlin/com/template/user/controller/request/AccessTokenUpdateRequest.kt
@@ -1,0 +1,8 @@
+package com.template.user.controller.request
+
+import javax.validation.constraints.NotBlank
+
+data class AccessTokenUpdateRequest(
+    @field:NotBlank(message = "refreshToken is required.")
+    val refreshToken: String = ""
+)

--- a/src/main/kotlin/com/template/user/controller/request/UserCreateRequest.kt
+++ b/src/main/kotlin/com/template/user/controller/request/UserCreateRequest.kt
@@ -1,0 +1,24 @@
+package com.template.user.controller.request
+
+import com.template.user.dto.UserCreateRequestDto
+import javax.validation.constraints.Email
+import javax.validation.constraints.NotBlank
+import javax.validation.constraints.NotEmpty
+
+data class UserCreateRequest(
+    @field:NotBlank(message = "name is required.")
+    val name: String,
+
+    @field:NotBlank(message = "password is required")
+    val password: String,
+
+    @field:Email(message = "wrong email format.")
+    @field:NotEmpty(message = "email is required.")
+    val email: String
+) {
+    fun toDto() = UserCreateRequestDto(
+        name = name,
+        password = password,
+        email = email
+    )
+}

--- a/src/main/kotlin/com/template/user/controller/request/UserLoginRequest.kt
+++ b/src/main/kotlin/com/template/user/controller/request/UserLoginRequest.kt
@@ -1,0 +1,16 @@
+package com.template.user.controller.request
+
+import com.template.user.dto.UserLoginRequestDto
+import javax.validation.constraints.Email
+import javax.validation.constraints.NotBlank
+
+data class UserLoginRequest(
+    @field:Email(message = "wrong email format.")
+    @field:NotBlank(message = "email is required.")
+    val email: String,
+
+    @field:NotBlank(message = "password is required.")
+    val password: String
+) {
+    fun toDto() = UserLoginRequestDto(email, password)
+}

--- a/src/main/kotlin/com/template/user/controller/response/AccessTokenUpdateResponse.kt
+++ b/src/main/kotlin/com/template/user/controller/response/AccessTokenUpdateResponse.kt
@@ -1,0 +1,11 @@
+package com.template.user.controller.response
+
+import com.template.user.dto.AccessTokenUpdateResponseDto
+
+data class AccessTokenUpdateResponse(
+    val accessToken: String = ""
+) {
+    companion object {
+        fun from(dto: AccessTokenUpdateResponseDto) = AccessTokenUpdateResponse(dto.accessToken)
+    }
+}

--- a/src/main/kotlin/com/template/user/controller/response/UserInfoResponse.kt
+++ b/src/main/kotlin/com/template/user/controller/response/UserInfoResponse.kt
@@ -1,0 +1,17 @@
+package com.template.user.controller.response
+
+import com.template.user.dto.UserInfoResponseDto
+
+data class UserInfoResponse(
+    val id: String,
+    val name: String,
+    val email: String
+) {
+    companion object {
+        fun from(dto: UserInfoResponseDto) = UserInfoResponse(
+            dto.id,
+            dto.name,
+            dto.email
+        )
+    }
+}

--- a/src/main/kotlin/com/template/user/controller/response/UserLoginResponse.kt
+++ b/src/main/kotlin/com/template/user/controller/response/UserLoginResponse.kt
@@ -1,0 +1,15 @@
+package com.template.user.controller.response
+
+import com.template.user.dto.UserLoginResponseDto
+
+data class UserLoginResponse(
+    val accessToken: String,
+    val refreshToken: String
+) {
+    companion object {
+        fun from(dto: UserLoginResponseDto) = UserLoginResponse(
+            dto.accessToken,
+            dto.refreshToken
+        )
+    }
+}

--- a/src/main/kotlin/com/template/user/dto/AccessTokenUpdateRequestDto.kt
+++ b/src/main/kotlin/com/template/user/dto/AccessTokenUpdateRequestDto.kt
@@ -1,8 +1,5 @@
 package com.template.user.dto
 
-import javax.validation.constraints.NotBlank
-
 data class AccessTokenUpdateRequestDto(
-    @field:NotBlank(message = "refreshToken is required.")
     val refreshToken: String = ""
 )

--- a/src/main/kotlin/com/template/user/dto/AccessTokenUpdateRequestDto.kt
+++ b/src/main/kotlin/com/template/user/dto/AccessTokenUpdateRequestDto.kt
@@ -1,5 +1,0 @@
-package com.template.user.dto
-
-data class AccessTokenUpdateRequestDto(
-    val refreshToken: String = ""
-)

--- a/src/main/kotlin/com/template/user/dto/UserCreateRequestDto.kt
+++ b/src/main/kotlin/com/template/user/dto/UserCreateRequestDto.kt
@@ -1,17 +1,7 @@
 package com.template.user.dto
 
-import javax.validation.constraints.Email
-import javax.validation.constraints.NotBlank
-import javax.validation.constraints.NotEmpty
-
 data class UserCreateRequestDto(
-    @field:NotBlank(message = "name is required.")
     val name: String,
-
-    @field:NotBlank(message = "password is required")
     val password: String,
-
-    @field:Email(message = "wrong email format.")
-    @field:NotEmpty(message = "email is required.")
     val email: String
 )

--- a/src/main/kotlin/com/template/user/dto/UserInfoResponseDto.kt
+++ b/src/main/kotlin/com/template/user/dto/UserInfoResponseDto.kt
@@ -7,5 +7,11 @@ data class UserInfoResponseDto(
     val name: String,
     val email: String
 ) {
-    constructor(user: User) : this(user.id!!, user.name, user.email)
+    companion object {
+        fun from(user: User) = UserInfoResponseDto(
+            user.id!!,
+            user.name,
+            user.email
+        )
+    }
 }

--- a/src/main/kotlin/com/template/user/dto/UserLoginRequestDto.kt
+++ b/src/main/kotlin/com/template/user/dto/UserLoginRequestDto.kt
@@ -1,13 +1,6 @@
 package com.template.user.dto
 
-import javax.validation.constraints.Email
-import javax.validation.constraints.NotBlank
-
 data class UserLoginRequestDto(
-    @field:Email(message = "wrong email format.")
-    @field:NotBlank(message = "email is required.")
     val email: String,
-
-    @field:NotBlank(message = "password is required.")
     val password: String
 )

--- a/src/test/kotlin/com/template/integration/user/UserAccessTokenUpdateTest.kt
+++ b/src/test/kotlin/com/template/integration/user/UserAccessTokenUpdateTest.kt
@@ -1,7 +1,7 @@
 package com.template.integration.user
 
 import com.template.integration.ApiIntegrationTest
-import com.template.user.dto.AccessTokenUpdateRequestDto
+import com.template.user.controller.request.AccessTokenUpdateRequest
 import com.template.util.generateExpiredToken
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
@@ -19,10 +19,10 @@ class UserAccessTokenUpdateTest : ApiIntegrationTest() {
     fun success() {
         val userId = generateUser().id!!
         val refreshToken = jwtTokenUtil.generateRefreshToken(userId)
-        val requestDto = AccessTokenUpdateRequestDto(refreshToken)
+        val request = AccessTokenUpdateRequest(refreshToken)
         client.post().uri(API_PATH)
             .header("Accept", MediaType.APPLICATION_JSON_VALUE)
-            .bodyValue(requestDto)
+            .bodyValue(request)
             .exchange()
             .expectStatus().isOk
             .expectHeader().contentType(MediaType.APPLICATION_JSON)
@@ -34,10 +34,10 @@ class UserAccessTokenUpdateTest : ApiIntegrationTest() {
     @Test
     fun failWithInvalidUserId() {
         val refreshToken = jwtTokenUtil.generateRefreshToken("WRONG_USER_ID")
-        val requestDto = AccessTokenUpdateRequestDto(refreshToken)
+        val request = AccessTokenUpdateRequest(refreshToken)
         val body = client.post().uri(API_PATH)
             .header("Accept", MediaType.APPLICATION_JSON_VALUE)
-            .bodyValue(requestDto)
+            .bodyValue(request)
             .exchange()
             .expectStatus().isUnauthorized
             .expectHeader().contentType(MediaType.APPLICATION_JSON)
@@ -49,10 +49,10 @@ class UserAccessTokenUpdateTest : ApiIntegrationTest() {
     @Test
     fun failWithExpiredRefreshToken() {
         val refreshToken = generateExpiredToken(Integer.valueOf(accessTokenExp), secret)
-        val requestDto = AccessTokenUpdateRequestDto(refreshToken)
+        val request = AccessTokenUpdateRequest(refreshToken)
         val body = client.post().uri(API_PATH)
             .header("Accept", MediaType.APPLICATION_JSON_VALUE)
-            .bodyValue(requestDto)
+            .bodyValue(request)
             .exchange()
             .expectStatus().isUnauthorized
             .expectHeader().contentType(MediaType.APPLICATION_JSON)

--- a/src/test/kotlin/com/template/integration/user/UserCreateTest.kt
+++ b/src/test/kotlin/com/template/integration/user/UserCreateTest.kt
@@ -1,8 +1,8 @@
 package com.template.integration.user
 
 import com.template.integration.ApiIntegrationTest
+import com.template.user.controller.request.UserCreateRequest
 import com.template.user.domain.User
-import com.template.user.dto.UserCreateRequestDto
 import com.template.util.EMAIL
 import com.template.util.NAME
 import com.template.util.PASSWORD
@@ -20,10 +20,10 @@ class UserCreateTest : ApiIntegrationTest() {
     @DisplayName("Success")
     @Test
     fun success() {
-        val requestDto = UserCreateRequestDto(NAME, PASSWORD, EMAIL)
+        val request = UserCreateRequest(NAME, PASSWORD, EMAIL)
         client.post().uri(API_PATH)
             .header("Accept", MediaType.APPLICATION_JSON_VALUE)
-            .bodyValue(requestDto)
+            .bodyValue(request)
             .exchange()
             .expectStatus().isCreated
             .expectHeader().contentType(MediaType.APPLICATION_JSON)
@@ -38,10 +38,10 @@ class UserCreateTest : ApiIntegrationTest() {
     @Test
     fun failWithConflictingEmail() {
         userRepository.save(User(NAME, EMAIL, PASSWORD)).block()
-        val requestDto = UserCreateRequestDto(NAME, PASSWORD, EMAIL)
+        val request = UserCreateRequest(NAME, PASSWORD, EMAIL)
         val body = client.post().uri(API_PATH)
             .header("Accept", MediaType.APPLICATION_JSON_VALUE)
-            .bodyValue(requestDto)
+            .bodyValue(request)
             .exchange()
             .expectStatus().isEqualTo(HttpStatus.CONFLICT)
             .expectHeader().contentType(MediaType.APPLICATION_JSON)
@@ -52,10 +52,10 @@ class UserCreateTest : ApiIntegrationTest() {
     @DisplayName("Fail - empty name")
     @Test
     fun failWithEmptyName() {
-        val requestDto = UserCreateRequestDto(" ", PASSWORD, EMAIL)
+        val request = UserCreateRequest(" ", PASSWORD, EMAIL)
         val body = client.post().uri(API_PATH)
             .header("Accept", MediaType.APPLICATION_JSON_VALUE)
-            .bodyValue(requestDto)
+            .bodyValue(request)
             .exchange()
             .expectStatus().isBadRequest
             .expectHeader().contentType(MediaType.APPLICATION_JSON)
@@ -66,10 +66,10 @@ class UserCreateTest : ApiIntegrationTest() {
     @DisplayName("Fail - empty email")
     @Test
     fun failWithEmptyEmail() {
-        val requestDto = UserCreateRequestDto(NAME, PASSWORD, " ")
+        val request = UserCreateRequest(NAME, PASSWORD, " ")
         val body = client.post().uri(API_PATH)
             .header("Accept", MediaType.APPLICATION_JSON_VALUE)
-            .bodyValue(requestDto)
+            .bodyValue(request)
             .exchange()
             .expectStatus().isBadRequest
             .expectHeader().contentType(MediaType.APPLICATION_JSON)
@@ -80,10 +80,10 @@ class UserCreateTest : ApiIntegrationTest() {
     @DisplayName("Fail - Wrong email format")
     @Test
     fun failWithWrongEmailFormat() {
-        val requestDto = UserCreateRequestDto(NAME, PASSWORD, "wrongEmailFormat")
+        val request = UserCreateRequest(NAME, PASSWORD, "wrongEmailFormat")
         val body = client.post().uri(API_PATH)
             .header("Accept", MediaType.APPLICATION_JSON_VALUE)
-            .bodyValue(requestDto)
+            .bodyValue(request)
             .exchange()
             .expectStatus().isBadRequest
             .expectHeader().contentType(MediaType.APPLICATION_JSON)

--- a/src/test/kotlin/com/template/integration/user/UserLoginTest.kt
+++ b/src/test/kotlin/com/template/integration/user/UserLoginTest.kt
@@ -1,8 +1,8 @@
 package com.template.integration.user
 
 import com.template.integration.ApiIntegrationTest
+import com.template.user.controller.request.UserLoginRequest
 import com.template.user.domain.User
-import com.template.user.dto.UserLoginRequestDto
 import com.template.util.EMAIL
 import com.template.util.NAME
 import com.template.util.PASSWORD
@@ -27,10 +27,10 @@ class UserLoginTest : ApiIntegrationTest() {
     @DisplayName("Success")
     @Test
     fun success() {
-        val requestDto = UserLoginRequestDto(EMAIL, PASSWORD)
+        val request = UserLoginRequest(EMAIL, PASSWORD)
         client.post().uri(API_PATH)
             .header("Accept", MediaType.APPLICATION_JSON_VALUE)
-            .bodyValue(requestDto)
+            .bodyValue(request)
             .exchange()
             .expectStatus().isOk
             .expectHeader().contentType(MediaType.APPLICATION_JSON)
@@ -42,10 +42,10 @@ class UserLoginTest : ApiIntegrationTest() {
     @DisplayName("Fail - Wrong email")
     @Test
     fun failWithWrongEmail() {
-        val requestDto = UserLoginRequestDto("wrong@email.com", PASSWORD)
+        val request = UserLoginRequest("wrong@email.com", PASSWORD)
         val body = client.post().uri(API_PATH)
             .header("Accept", MediaType.APPLICATION_JSON_VALUE)
-            .bodyValue(requestDto)
+            .bodyValue(request)
             .exchange()
             .expectStatus().isNotFound
             .expectHeader().contentType(MediaType.APPLICATION_JSON)
@@ -56,10 +56,10 @@ class UserLoginTest : ApiIntegrationTest() {
     @DisplayName("Fail - Wrong password")
     @Test
     fun failWithWrongPassword() {
-        val requestDto = UserLoginRequestDto(EMAIL, "wrongPassword")
+        val request = UserLoginRequest(EMAIL, "wrongPassword")
         val body = client.post().uri(API_PATH)
             .header("Accept", MediaType.APPLICATION_JSON_VALUE)
-            .bodyValue(requestDto)
+            .bodyValue(request)
             .exchange()
             .expectStatus().isNotFound
             .expectHeader().contentType(MediaType.APPLICATION_JSON)
@@ -70,10 +70,10 @@ class UserLoginTest : ApiIntegrationTest() {
     @DisplayName("Fail - Empty email")
     @Test
     fun wailWithEmptyEmail() {
-        val requestDto = UserLoginRequestDto("", PASSWORD)
+        val request = UserLoginRequest("", PASSWORD)
         val body = client.post().uri(API_PATH)
             .header("Accept", MediaType.APPLICATION_JSON_VALUE)
-            .bodyValue(requestDto)
+            .bodyValue(request)
             .exchange()
             .expectStatus().isBadRequest
             .expectHeader().contentType(MediaType.APPLICATION_JSON)
@@ -84,10 +84,10 @@ class UserLoginTest : ApiIntegrationTest() {
     @DisplayName("Fail - Wrong email format")
     @Test
     fun failWithWrongEmailFormat() {
-        val requestDto = UserLoginRequestDto("wrongEmailFormat", PASSWORD)
+        val request = UserLoginRequest("wrongEmailFormat", PASSWORD)
         val body = client.post().uri(API_PATH)
             .header("Accept", MediaType.APPLICATION_JSON_VALUE)
-            .bodyValue(requestDto)
+            .bodyValue(request)
             .exchange()
             .expectStatus().isBadRequest
             .expectHeader().contentType(MediaType.APPLICATION_JSON)
@@ -98,10 +98,10 @@ class UserLoginTest : ApiIntegrationTest() {
     @DisplayName("Fail - Empty password")
     @Test
     fun failWithEmptyPassword() {
-        val requestDto = UserLoginRequestDto(EMAIL, " ")
+        val request = UserLoginRequest(EMAIL, " ")
         val body = client.post().uri(API_PATH)
             .header("Accept", MediaType.APPLICATION_JSON_VALUE)
-            .bodyValue(requestDto)
+            .bodyValue(request)
             .exchange()
             .expectStatus().isBadRequest
             .expectHeader().contentType(MediaType.APPLICATION_JSON)

--- a/src/test/kotlin/com/template/unit/user/UserAccessTokenUpdateServiceUnitTest.kt
+++ b/src/test/kotlin/com/template/unit/user/UserAccessTokenUpdateServiceUnitTest.kt
@@ -4,7 +4,6 @@ import com.ninjasquad.springmockk.MockkBean
 import com.template.security.exception.AuthenticateException
 import com.template.security.tools.JwtTokenUtil
 import com.template.unit.BaseUnitTest
-import com.template.user.dto.AccessTokenUpdateRequestDto
 import com.template.user.service.UserService
 import com.template.util.JWT_REFRESH_TOKEN_EXP
 import com.template.util.TOKEN
@@ -43,8 +42,7 @@ class UserAccessTokenUpdateServiceUnitTest : BaseUnitTest() {
         val user = getMockUser()
         every { userRepository.findById(any<String>()) } returns Mono.just(user)
         val refreshToken = jwtTokenUtil.generateRefreshToken(user.id!!)
-        val requestDto = AccessTokenUpdateRequestDto(refreshToken)
-        userService.updateAccessToken(Mono.just(requestDto))
+        userService.updateAccessToken(Mono.just(refreshToken))
             .`as`(StepVerifier::create)
             .expectNextMatches {
                 it.statusCode shouldBe HttpStatus.OK
@@ -58,8 +56,7 @@ class UserAccessTokenUpdateServiceUnitTest : BaseUnitTest() {
     @Test
     fun failWithExpiredRefreshToken() {
         val refreshToken = generateExpiredToken(JWT_REFRESH_TOKEN_EXP, jwtProperties.secret)
-        val requestDto = AccessTokenUpdateRequestDto(refreshToken)
-        userService.updateAccessToken(Mono.just(requestDto))
+        userService.updateAccessToken(Mono.just(refreshToken))
             .`as`(StepVerifier::create)
             .expectErrorMatches {
                 it.message shouldBe "Jwt 토큰이 만료되었습니다."
@@ -73,8 +70,7 @@ class UserAccessTokenUpdateServiceUnitTest : BaseUnitTest() {
     fun failWithInvalidUserId() {
         every { userRepository.findById(any<String>()) } returns Mono.empty()
         val refreshToken = jwtTokenUtil.generateRefreshToken(USER_ID)
-        val requestDto = AccessTokenUpdateRequestDto(refreshToken)
-        userService.updateAccessToken(Mono.just(requestDto))
+        userService.updateAccessToken(Mono.just(refreshToken))
             .`as`(StepVerifier::create)
             .expectErrorMatches {
                 it.message shouldBe "Invalid userId."


### PR DESCRIPTION
- request dto, response dto는 service-domain layer로 사용되게끔 하고, controller layer에서 직접적으로 사용하지 않도록 했다.
